### PR TITLE
Run package build upon installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
 		"postversion": "npm run readme && npm run b:lib",
 		"publish:patch": "np patch --contents=dist --no-cleanup",
 		"publish:minor": "np minor --contents=dist --no-cleanup",
-		"publish:major": "np major --contents=dist --no-cleanup"
+		"publish:major": "np major --contents=dist --no-cleanup",
+		"postinstall": "b:lib"
 	},
 	"devDependencies": {
 		"@appnest/readme": "^1.2.5",


### PR DESCRIPTION
Because this package will currently be installed from GitHub rather than an npm registry, its hooks to build the package aren't currently run with the defined scripts. Adding a `postinstall` script will make sure the package is properly built when another package installs it.